### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
 [![Build Status](https://travis-ci.org/ckan/deadoralive.svg)](https://travis-ci.org/ckan/deadoralive)
 [![Coverage Status](https://img.shields.io/coveralls/ckan/deadoralive.svg)](https://coveralls.io/r/ckan/deadoralive)
-[![Latest Version](https://pypip.in/version/deadoralive/badge.svg)](https://pypi.python.org/pypi/deadoralive/)
-[![Downloads](https://pypip.in/download/deadoralive/badge.svg)](https://pypi.python.org/pypi/deadoralive/)
-[![Supported Python versions](https://pypip.in/py_versions/deadoralive/badge.svg)](https://pypi.python.org/pypi/deadoralive/)
-[![Development Status](https://pypip.in/status/deadoralive/badge.svg)](https://pypi.python.org/pypi/deadoralive/)
-[![License](https://pypip.in/license/deadoralive/badge.svg)](https://pypi.python.org/pypi/deadoralive/)
+[![Latest Version](https://img.shields.io/pypi/v/deadoralive.svg)](https://pypi.python.org/pypi/deadoralive/)
+[![Downloads](https://img.shields.io/pypi/dm/deadoralive.svg)](https://pypi.python.org/pypi/deadoralive/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/deadoralive.svg)](https://pypi.python.org/pypi/deadoralive/)
+[![Development Status](https://img.shields.io/pypi/status/deadoralive.svg)](https://pypi.python.org/pypi/deadoralive/)
+[![License](https://img.shields.io/pypi/l/deadoralive.svg)](https://pypi.python.org/pypi/deadoralive/)
 
 
 Dead or Alive


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20deadoralive))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `deadoralive`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.